### PR TITLE
Correct questionMark.svg import path

### DIFF
--- a/app/containers/RedeemPage/index.js
+++ b/app/containers/RedeemPage/index.js
@@ -12,7 +12,7 @@ import Pagination from 'antd/lib/pagination';
 import 'antd/lib/table/style/css';
 import 'antd/lib/pagination/style/css';
 import Constants from 'components/Constants';
-import QuestionMark from 'components/input/questionMark.svg';
+import QuestionMark from 'components/Input/questionMark.svg';
 import Img from 'components/Img';
 import Button from 'components/Button';
 import Tooltip from 'components/Tooltip';


### PR DESCRIPTION
Corrects a small capitalization error in an import path. The `RedeemPage` code imports `components/input/questionMark.svg`. The file is at `components/Input/questionMark.svg`. Running the site locally shows this error:

```
ERROR in ./app/containers/RedeemPage/index.js
Module not found: Error: Can't resolve 'components/input/questionMark.svg' in '/home/user/repo/github/bookmoons/MyBit-Trust.website/app/containers/RedeemPage'
 @ ./app/containers/RedeemPage/index.js 27:0-61 184:19-31
 @ ./app/containers/RedeemPage/Loadable.js
 @ ./app/containers/App/index.js
 @ ./app/app.js
 @ multi eventsource-polyfill webpack-hot-middleware/client?reload=true ./app/app.js
```

Captalizes `Input` in the import path.

A code search finds no other imports of the file needing update.